### PR TITLE
修复柱状图显示x轴单位位置的bug

### DIFF
--- a/lib/charts/column.js
+++ b/lib/charts/column.js
@@ -147,6 +147,7 @@
     }
     this.columns = _.groupBy(dataTable, map.column);
     this.columnCount = _.keys(this.columns).length;
+
     conf.xAxisData = _.pluck(_.first(_.values(this.columns)), map.x);
     conf.xTickNumber = Math.min(conf.xAxisData.length, conf.xTickNumber);
     // 纵坐标的范围
@@ -177,12 +178,16 @@
     this.value = d3.scale.linear().domain(conf.yExtent).range([h, conf.margin]);
     var xRange = this.x.range();
     var valueRange = this.value.range();
-    this.axisPosition = {
+    var axis = this.axisPosition = {
       left: xRange[0],
       right: xRange[1],
       up: valueRange[1],
       down: valueRange[0]
     };
+    var columnsMaxLen = _.max(this.columns, function (column) {
+      return column.length;
+    }).length;
+    this.barWidth = (axis.right - axis.left - columnsMaxLen * conf.gap) / columnsMaxLen / _.keys(this.columns).length;
   };
 
   /**
@@ -202,12 +207,16 @@
     ticks = this.x.ticks(conf.xTickNumber);
     console.log(ticks);
     var range = this.x.range();
-    var diff = (range[1] - range[0]) / ticks.length;
-    for (j = 1; j < ticks.length; j++) {
-      var x = this.x(ticks[j]) - diff + conf.gap / 2;
-      tickText.push(paper.text(x, axis.down + 14, conf.xAxisData[ticks[j] - 1]).rotate(0, x, axis.up));
+
+    // 修复显示不从第一个x轴单位显示的bug
+    for (j = 0; j < ticks.length; j++) {
+      // 修改x轴单位显示在所有Column组的中间位置
+      // 修复x轴单位对于柱位置的偏移
+      var x = this.x(ticks[j]) + conf.gap / 2 + this.columnCount * Math.floor(this.barWidth) / 2;
+      tickText.push(paper.text(x, axis.down + 14, conf.xAxisData[ticks[j]]).rotate(0, x, axis.up));
       axisLines.push(paper.path("M" + x + "," + axis.down + "L" + x + "," + (axis.down + 5)));
     }
+
     tickText.attr({
       "fill": "#878791",
       "fill-opacity": 0.7,
@@ -259,10 +268,7 @@
     var paper = this.canvas;
     var dim = that.dimension;
     //bars
-    var maxLength = _.max(this.columns, function (column) {
-      return column.length;
-    }).length;
-    var barWidth = (axis.right - axis.left - maxLength * conf.gap) / maxLength / _.keys(this.columns).length;
+    var barWidth = this.barWidth;
     var columnCount = this.columnCount;
     var columnSet = this.columnSet;
     var values = _.values(this.columns);


### PR DESCRIPTION
将x轴单位显示位置修改到多个柱状图正中
修复x轴单位显示的微小偏移
修复x轴单位没有从第一个传入单位显示的bug
