### PR TITLE
采用删除svg而不是重置svg，重置svg会导致创建2个svg对象在DOM节点中

### DIFF
--- a/lib/charts/line.js
+++ b/lib/charts/line.js
@@ -384,7 +384,7 @@
    * @param {object} options options json object for determin line style.
    */
   Line.prototype.render = function () {
-    this.canvas.clear();
+    this.canvas.remove();
     this.createCanvas();
     var conf = this.defaults;
     var linesData = this.linesData;
@@ -419,7 +419,6 @@
         var y = y0 - ((nodeData[j] - min) * yMatchNum);
 
         linePath = linePath + x + "," + y;
-        
         if (j < l - 1) {
           linePath = linePath + "L";
         }
@@ -502,7 +501,6 @@
     $(this.node).append(this.floatTag);
     // if (hoverMode) {
     //  background.mouseover(function () {
-        
   //    }).mouseout(function () {
   //      floatTag.css({"visibility" : "hidden"});
   //    });


### PR DESCRIPTION
原因是你构造的时候调用了一次createCanvas，然后在render的时候又再次调用。所以会执行两次 new Repheal的操作。
